### PR TITLE
Fixing typeerror on api creation

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,69 +1,47 @@
-var Structr = require('structr'),
-xmlrpc = require('xmlrpc'),
+var xmlrpc = require('xmlrpc'),
 Url = require('url');
 
+function api(host) {
+  var hostParts = {};
+        
+  if(typeof host == 'string')
+  {
+      hostParts = Url.parse(host);
+      
+      if(hostParts.auth)
+      {
+          var authParts = hostParts.auth.split(':');
+          hostParts.user = authParts[0];
+          hostParts.pass = authParts[1];
+      }
+  }
+  else if(host)
+  {
+      hostParts = host;
+  }
+  
+  
+  if(!hostParts.hostname) hostParts.hostname = 'localhost';
+  if(!hostParts.port) hostParts.port = 9001;
+  
+  
+  this.client = xmlrpc.createClient({
+      host: hostParts.hostname,
+      port: hostParts.port,
+      path: '/RPC2',
+      basic_auth: {
+          user: hostParts.user,
+          pass: hostParts.pass
+      }
+  });
+}
 
-
-var __part = {
-
-    /**
-     */
-     
-     
-    'override __construct': function(host)
-    {
-        this._super();
-        
-        var hostParts = {};
-        
-        if(typeof host == 'string')
-        {
-            hostParts = Url.parse(host);
-            
-            if(hostParts.auth)
-            {
-                var authParts = hostParts.auth.split(':');
-                hostParts.user = authParts[0];
-                hostParts.pass = authParts[1];
-            }
-            
-        }
-        else
-        if(host)
-        {
-            hostParts = host;
-        }
-        
-        
-        if(!hostParts.hostname) hostParts.hostname = 'localhost';
-        if(!hostParts.port) hostParts.port = 9001;
-        
-        
-        this.client = xmlrpc.createClient({
-            host: hostParts.hostname,
-            port: hostParts.port,
-            path: '/RPC2',
-            basic_auth: {
-                user: hostParts.user,
-                pass: hostParts.pass
-            }
-        });
-    },
-    
-    
-    /**
-     */
-     
-    '_call': function(method, args, callback)
-    {
-        this.client.methodCall(method, args, callback);
-    }
+api.prototype._call = function(method, args, callback)
+{
+    this.client.methodCall(method, args, callback);
 };
 
-
-
-//yeah yeah, it'd certainly look cleaner if I wrote all these methods out, but I'm lazy.
-[ 'supervisor.addProcessGroup',
+['supervisor.addProcessGroup',
   'supervisor.clearAllProcessLogs',
   'supervisor.clearLog',
   'supervisor.clearProcessLog',
@@ -100,18 +78,12 @@ var __part = {
   'system.listMethods',
   'system.methodHelp',
   'system.methodSignature',
-  'system.multicall' ].forEach(function(property)
-{
-    
-    //add onto the prototype
-    __part[ property.split('.').pop() ] = function()
-    {
-        var args = Structr.argsToArray(arguments),
-        callback = args.pop();
-        
-        this._call(property, args, callback);
-    }
+  'system.multicall'].forEach(function(property){
+  api.prototype[property.split('.').pop()] = function(){
+    var args = Array.prototype.slice.call(arguments);
+    callback = args.pop();
+    this._call(property, args, callback);
+  };
 });
 
-
-module.exports = Structr(__part); 
+module.exports = api;


### PR DESCRIPTION
This module was throwing a "Typeerror: Object is not a function" when it was being created on index.js. I wasn't sure what was changed, but it seemed to be caused by how Structr was creating the object.

I Refactored it a bit and removed the dependency on Structr, while still keeping the way it (awesomely :P) lazily loaded the supervisor method calls through to the xmlrpc module.

It now works exactly as demonstrated in the docs, and is being actively used in a node app which we'll be publishing shortly.
